### PR TITLE
Sync internal change to GitHub

### DIFF
--- a/.github/workflows/.aspect-workflows-reusable.yaml
+++ b/.github/workflows/.aspect-workflows-reusable.yaml
@@ -1,7 +1,7 @@
 # ==================================================================================================
-# Aspect Workflows Reusable Workflow for GitHub Actions v5.12.9
+# Aspect Workflows Reusable Workflow for GitHub Actions v5.12.22
 #
-# https://github.com/aspect-build/workflows-action/blob/5.12.9/.github/workflows/.aspect-workflows-reusable.yaml
+# https://github.com/aspect-build/workflows-action/blob/5.12.22/.github/workflows/.aspect-workflows-reusable.yaml
 #
 # At this time, GitHub Actions does not allow referencing reusable workflows from public
 # repositories in other organizations. See
@@ -37,7 +37,7 @@
 #    jobs:
 #      aspect-workflows:
 #        name: Aspect Workflows
-#        uses: my-github-org/workflows-action/.github/workflows/.aspect-workflows-reusable.yaml@5.12.9
+#        uses: my-github-org/workflows-action/.github/workflows/.aspect-workflows-reusable.yaml@5.12.22
 #    ```
 # ==================================================================================================
 name: Aspect Workflows Reusable Workflow
@@ -118,14 +118,14 @@ jobs:
           write_output_files: true
           output_dir: ${{ fromJson(needs.setup.outputs.cfg).platform.directories.ARTIFACTS_DIR }}
       - name: Checkout health
-        uses: aspect-build/workflows-action@5.12.9
+        uses: aspect-build/workflows-action@5.12.22
         timeout-minutes: ${{ fromJson(needs.setup.outputs.cfg).workflows_config[matrix.job].checkout_task_timeout }}
         if: fromJson(needs.setup.outputs.cfg).workflows_config[matrix.job].has_checkout_task
         with:
           workspace: ${{ fromJson(needs.setup.outputs.cfg).workflows_config[matrix.job].workspace }}
           task: checkout
       - name: ${{ fromJson(needs.setup.outputs.cfg).workflows_config[matrix.job].name }}
-        uses: aspect-build/workflows-action@5.12.9
+        uses: aspect-build/workflows-action@5.12.22
         env: ${{ inputs.inherited_secrets != '' && fromJson(steps.process_secrets.outputs.filtered_secrets) || fromJson('{}') }}
         timeout-minutes: ${{ fromJson(needs.setup.outputs.cfg).workflows_config[matrix.job].timeout_in_minutes }}
         with:
@@ -145,7 +145,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets[inputs.slack_webhook_url] }}
       - name: Delivery manifest
         if: fromJson(needs.setup.outputs.cfg).workflows_config[matrix.job].generate_manifest
-        uses: aspect-build/workflows-action@5.12.9
+        uses: aspect-build/workflows-action@5.12.22
         timeout-minutes: ${{ fromJson(needs.setup.outputs.cfg).workflows_config[matrix.job].delivery_manifest_timeout }}
         with:
           workspace: ${{ fromJson(needs.setup.outputs.cfg).workflows_config[matrix.job].workspace }}

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you forked the repo to your org, then replace `my-org` with your org in this 
 jobs:
     aspect-workflows:
         name: Aspect Workflows
-        uses: my-org/workflows-action/.github/workflows/.aspect-workflows-reusable.yaml@5.12.9
+        uses: my-org/workflows-action/.github/workflows/.aspect-workflows-reusable.yaml@5.12.22
 ```
 
 If you vendored the file, then instead it will be:
@@ -110,7 +110,7 @@ jobs:
             - name: Agent health check
               run: /etc/aspect/workflows/bin/agent_health_check
             - name: Run delivery
-              uses: aspect-build/workflows-action@5.12.9
+              uses: aspect-build/workflows-action@5.12.22
               with:
                   task: delivery
                   workspace: ${{ inputs.workspace }}


### PR DESCRIPTION
There's something that overrides `--remote_download_outputs=all` as `--remote_donload_outputs=toplevel` behind the scene. I'd like to update the aspect to the latest version to resolve the issue. here's the [slack conversation reference](https://stairw3ll.slack.com/archives/C056K5XUEVD/p1745952707083689).